### PR TITLE
Custom split to generics datas in many levels

### DIFF
--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:auto_injector/auto_injector.dart';
+import 'package:fake_reflection/fake_reflection.dart'
+    show FakeReflectionExtension;
 
 enum BindType {
   instance,
@@ -42,8 +44,48 @@ class Bind<T> {
     T? instance,
   }) {
     final constructorString = constructor.runtimeType.toString();
-    final className = _resolveClassName<T>(constructorString);
-    final params = _extractParams(constructorString);
+    final constructorListString = constructorString.split(' ');
+    final paramsString = constructorListString[0];
+    final classNameString = constructorListString.last;
+    if (paramsString == '()') {
+      return Bind<T>._(
+        constructor: constructor,
+        className: classNameString,
+        params: [],
+        type: type,
+        config: config,
+        instance: instance,
+      );
+    }
+
+    final classData = constructor.reflection();
+    final className = classData.className;
+
+    final params = [
+      ...classData.namedParams.map(
+        (param) => NamedParam(
+          className: param.type,
+          isNullable: param.nullable,
+          isRequired: param.required,
+          named: Symbol(param.name),
+        ),
+      ),
+      ...classData.notRequiredPositionalParams.map(
+        (param) => PositionalParam(
+          className: param.type,
+          isNullable: param.nullable,
+          isRequired: false,
+        ),
+      ),
+      ...classData.positionalParams.map(
+        (param) => PositionalParam(
+          className: param.type,
+          isNullable: param.nullable,
+          isRequired: true,
+        ),
+      ),
+    ];
+
     return Bind<T>._(
       constructor: constructor,
       className: className,
@@ -104,98 +146,5 @@ class Bind<T> {
       instance: instance,
       config: config,
     );
-  }
-
-  static List<String> _customSplit(String input) {
-    final parts = <String>[];
-    var currentPart = '';
-    var angleBracketCount = 0;
-
-    for (final char in input.runes) {
-      final charStr = String.fromCharCode(char);
-
-      if (charStr == ',' && angleBracketCount == 0) {
-        parts.add(currentPart.trim());
-        currentPart = '';
-      } else {
-        currentPart += charStr;
-
-        if (charStr == '<') {
-          angleBracketCount++;
-        } else if (charStr == '>') {
-          angleBracketCount--;
-        }
-      }
-    }
-
-    if (currentPart.isNotEmpty && currentPart != ' ') {
-      parts.add(currentPart.trim());
-    }
-
-    return parts;
-  }
-
-  static List<Param> _extractParams(String constructorString) {
-    final params = <Param>[];
-
-    if (constructorString.startsWith('() => ')) {
-      return params;
-    }
-
-    final allArgsRegex = RegExp(r'\((.+)\) => .+');
-
-    final allArgsMatch = allArgsRegex.firstMatch(constructorString);
-
-    var allArgs = allArgsMatch!.group(1)!;
-
-    final hasNamedParams = RegExp(r'\{(.+)\}');
-    final namedParams = hasNamedParams.firstMatch(allArgs);
-
-    if (namedParams != null) {
-      final named = namedParams.group(1)!;
-      allArgs = allArgs.replaceAll('{$named}', '');
-
-      final paramsText = _customSplit(named);
-
-      for (final paramText in paramsText) {
-        final anatomicParamText = paramText.split(' ');
-
-        final type = anatomicParamText[anatomicParamText.length - 2];
-        final named = Symbol(anatomicParamText.last);
-
-        final param = NamedParam(
-          isRequired: anatomicParamText.contains('required'),
-          named: named,
-          isNullable: type.endsWith('?'),
-          className: type.replaceFirst('?', ''),
-        );
-
-        params.add(param);
-      }
-    }
-
-    if (allArgs.isNotEmpty) {
-      final paramList = _customSplit(allArgs);
-      final allParam =
-          paramList.map((e) => e.trim()).where((e) => e.isNotEmpty).map((e) {
-        return PositionalParam(
-          className: e.replaceFirst('?', ''),
-          isNullable: e.endsWith('?'),
-        );
-      }).toList();
-
-      params.addAll(allParam);
-    }
-
-    return params;
-  }
-
-  static String _resolveClassName<T>(String constructorString) {
-    final typeName = T.toString();
-    final isDynamicOrObjectType = ['dynamic', 'Object'].contains(typeName);
-    if (!isDynamicOrObjectType) return typeName;
-
-    final className = constructorString.split(' => ').last;
-    return className;
   }
 }

--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -106,6 +106,35 @@ class Bind<T> {
     );
   }
 
+  static List<String> _customSplit(String input) {
+    final parts = <String>[];
+    var currentPart = '';
+    var angleBracketCount = 0;
+
+    for (final char in input.runes) {
+      final charStr = String.fromCharCode(char);
+
+      if (charStr == ',' && angleBracketCount == 0) {
+        parts.add(currentPart.trim());
+        currentPart = '';
+      } else {
+        currentPart += charStr;
+
+        if (charStr == '<') {
+          angleBracketCount++;
+        } else if (charStr == '>') {
+          angleBracketCount--;
+        }
+      }
+    }
+
+    if (currentPart.isNotEmpty && currentPart != ' ') {
+      parts.add(currentPart.trim());
+    }
+
+    return parts;
+  }
+
   static List<Param> _extractParams(String constructorString) {
     final params = <Param>[];
 
@@ -126,7 +155,7 @@ class Bind<T> {
       final named = namedParams.group(1)!;
       allArgs = allArgs.replaceAll('{$named}', '');
 
-      final paramsText = named.split(',').map((e) => e.trim()).toList();
+      final paramsText = _customSplit(named);
 
       for (final paramText in paramsText) {
         final anatomicParamText = paramText.split(' ');
@@ -146,11 +175,9 @@ class Bind<T> {
     }
 
     if (allArgs.isNotEmpty) {
-      final allParam = allArgs //
-          .split(',')
-          .map((e) => e.trim())
-          .where((e) => e.isNotEmpty)
-          .map((e) {
+      final paramList = _customSplit(allArgs);
+      final allParam =
+          paramList.map((e) => e.trim()).where((e) => e.isNotEmpty).map((e) {
         return PositionalParam(
           className: e.replaceFirst('?', ''),
           isNullable: e.endsWith('?'),

--- a/lib/src/param.dart
+++ b/lib/src/param.dart
@@ -1,4 +1,5 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
+// ignore_for_file: public_member_api_docs
+
 import 'package:meta/meta.dart';
 
 typedef ParamTransform = Param? Function(Param param);
@@ -62,6 +63,7 @@ class NamedParam extends Param {
 class PositionalParam extends Param {
   PositionalParam({
     required super.className,
+    required super.isRequired,
     super.value,
     super.isNullable = false,
   });
@@ -72,6 +74,7 @@ class PositionalParam extends Param {
       className: className,
       isNullable: isNullable,
       value: value,
+      isRequired: isRequired,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,11 @@ version: 1.2.0
 repository: https://github.com/Flutterando/auto_injector
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  meta: '>=1.5.0 <2.0.0'
+  fake_reflection: ">=1.0.1 <2.0.0"
+  meta: ">=1.5.0 <2.0.0"
   uuid: ^3.0.7
 
 dev_dependencies:

--- a/test/src/auto_injector_base_test.dart
+++ b/test/src/auto_injector_base_test.dart
@@ -123,6 +123,13 @@ void main() {
       expect(injector.get<TestRepository>(), isA<TestRepository>());
     });
 
+    test('Get instance with named params with Map generics', () {
+      injector.add(TestComplexNamed.new);
+      injector.commit();
+
+      expect(injector.get<TestComplexNamed>(), isA<TestComplexNamed>());
+    });
+
     test('Get instance with named params', () {
       injector.add(TestRepository.new);
       injector.add(TestDatasource.new);
@@ -404,6 +411,14 @@ class TestRepository {
 
   TestRepository({required this.datasource, this.text});
 }
+
+class TestComplexNamed {
+  final Map<String, dynamic>? value;
+  final Map<String, List<Map<String, dynamic>>>? map;
+
+  TestComplexNamed({this.value, this.map});
+}
+
 
 class TestDatasource {}
 


### PR DESCRIPTION
# The problem
AutoInjector breaks when calling .new and the parameters have generics 

# Expected Behavior
When calling .new with parameters with generics, the process should continue to find the bind

# What does this PR do
This PR fixes this problem without much complexity, in up to 3 levels of generics