### PR TITLE
Bump dependencies versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  meta: ">=1.5.0 <2.0.0"
-  uuid: ^3.0.7
+  meta: ">=1.11.0 <2.0.0"
+  uuid: ^4.2.1
 
 dev_dependencies:
   flutterando_analysis: ^0.0.2


### PR DESCRIPTION
# The problem
Auto injector depends on `uuid: ^3.0.7`, which is from 12 months ago and `meta: ">=1.5.0 <2.0.0"`, which is from 2 years ago.

This makes auto injector incompatible with packages that constraints `uuid` to ^4.0.0 or higher and `meta` to ^1.6.0 or higher.

# What does this PR do
This PR increases the version of `uuid` and `meta` to make it compatible with more packages