### PR TITLE
Fix: Instance callback on dispose

### DIFF
--- a/lib/src/auto_injector_base.dart
+++ b/lib/src/auto_injector_base.dart
@@ -422,7 +422,7 @@ It is recommended to call the "commit()" method after adding instances.'''
     }
     disposeListeners.clear();
     for (final bind in binds.where((b) => b.instance != null)) {
-      instanceCallback?.call(bind);
+      instanceCallback?.call(bind.instance);
       bind.callDispose();
     }
     binds.clear();


### PR DESCRIPTION
# The problem
On dispose method when instanceCallback is called, the argument passed is the bind instead of the instance.

# What does this PR do
This PR fixes this problem,  passing the instance `bind.instance` instead of bind when the instanceCallback is called.